### PR TITLE
Fix bug in metric sequencing 

### DIFF
--- a/demeter/demeter_io/reader.py
+++ b/demeter/demeter_io/reader.py
@@ -362,6 +362,10 @@ def read_base(log, c, spat_landclasses, sequence_metric_dict, metric_seq, region
         log.error('Observed spatial data must have all {}_id represented.'.format(c.metric.lower()))
         raise ValidationException
 
+    # account for 0 designation in observed data for unclassified
+    if 0 in np.unique(spat_metric):
+        sequence_metric_dict[0] = 0
+
     # adjust the numbering of metrics in the observed data
     spat_metric = np.vectorize(sequence_metric_dict.get)(spat_metric)
 

--- a/demeter/demeter_io/reader.py
+++ b/demeter/demeter_io/reader.py
@@ -12,6 +12,12 @@ import os
 import pandas as pd
 
 
+class ValidationException(Exception):
+    """Validation exception for error in runtime test."""
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+
 def to_dict(f, header=False, delim=',', swap=False):
     """
     Return a dictionary of key: value pairs.  Supports only key to one value.
@@ -176,7 +182,8 @@ def _get_steps(df, start_step, end_step):
     return l
 
 
-def read_gcam_file(log, f, gcam_landclasses, start_yr, end_yr, scenario, region_dict, agg_level, area_factor=1000):
+def read_gcam_file(log, f, gcam_landclasses, start_yr, end_yr, scenario, region_dict, agg_level, metric_seq,
+                   area_factor=1000):
     """
     Read and process the GCAM land allocation output file.
 
@@ -187,6 +194,7 @@ def read_gcam_file(log, f, gcam_landclasses, start_yr, end_yr, scenario, region_
     :param end_yr:              User-defined GCAM end year to process from configuration file
     :param scenario:            GCAM scenario name contained in file that the user wishes to process; set in config.ini
     :param region_dict:         The reference dictionary for GCAM region_name: region_id
+    :param metric_seq:          An ordered list of expected metric ids
     :param area_factor:         The factor that will be a multiplier to the land use area that is in thousands km
     :return:                    A list of the following (represents the target user-defined scenario):
                                     user_years:             a list of target GCAM years as int
@@ -198,7 +206,6 @@ def read_gcam_file(log, f, gcam_landclasses, start_yr, end_yr, scenario, region_
                                     allregnumber:           Numpy array of unique region numbers
                                     allregaez:              List of lists, metric ids per region
     """
-
     # read GCAM output file as a dataframe; skip title row
     gdf = pd.read_csv(f, header=0)
 
@@ -213,19 +220,29 @@ def read_gcam_file(log, f, gcam_landclasses, start_yr, end_yr, scenario, region_
 
     # create land use area per year array converted from thousands km using area_factor
     target_years = [str(yr) for yr in user_years]
-
     gcam_ludata = gdf[target_years].values * area_factor
 
     # create field for land class
     gdf['gcam_landname'] = gdf['landclass'].apply(lambda x: x.lower())
 
+    unique_metric_list = np.sort(gdf['metric_id'].unique())
+
+    # get a list of metrics that are in the master list but not the projected data
+    metric_not_in_prj = sorted(list(set(metric_seq) - set(unique_metric_list)))
+
     # create dictionary to look up metric id to its index to act as a proxy for non-sequential values
     sequence_metric_dict = {i: ix+1 for ix, i in enumerate(gdf['metric_id'].sort_values().unique())}
+
+    max_prj_metric = max([sequence_metric_dict[k] for k in sequence_metric_dict.keys()]) + 1
+
+    for i in metric_not_in_prj:
+        sequence_metric_dict[i] = max_prj_metric
+        max_prj_metric += 1
 
     # create field for metric id that has sequential metric ids
     gdf['gcam_metric'] = gdf['metric_id'].map(lambda x: sequence_metric_dict[x])
 
-    # check field for GCAM region number based off of region name; if region name is None, assign 9999
+    # check field for GCAM region number based off of region name; if region name is None, assign 1
     ck_reg = gdf['region'].unique()
     if (len(ck_reg)) == 1 and (ck_reg[0] == 1):
         gdf['gcam_regionnumber'] = 1
@@ -281,24 +298,24 @@ def read_gcam_file(log, f, gcam_landclasses, start_yr, end_yr, scenario, region_
             allmetric, metric_id_array, sequence_metric_dict]
 
 
-def read_base(log, c, spat_landclasses, sequence_metric_dict):
+def read_base(log, c, spat_landclasses, sequence_metric_dict, metric_seq, region_seq):
     """
     Read and process base layer land cover file.
 
-    :param f:
-    :param spat_landclasses:
-    :param resolution:
+    :param c:                           Configuration object
+    :param spat_landclasses:            A list of land classes represented in the observed data
+    :param sequence_metric_dict:        A dictionary of projected metric ids to their original id
+    :param metric_seq:                  An ordered list of expected metric ids
+    :param region_seq:                  An ordered list of expected region ids
     :return:
     """
-
-    # read base layer as a dataframe
     df = pd.read_csv(c.first_mod_file)
 
     # rename columns as lower case
     df.columns = [i.lower() for i in df.columns]
 
+    # create array with only spatial land cover values
     try:
-        # create array with only spatial land cover values
         spat_ludata = df[spat_landclasses].values
     except KeyError as e:
         log.error('Fields are listed in the spatial allocation file that do not exist in the base layer.')
@@ -319,46 +336,33 @@ def read_base(log, c, spat_landclasses, sequence_metric_dict):
     # create array of grid ids
     spat_grid_id = df[c.pkey].values
 
+    # create array of water areas
     try:
-        # create array of water areas
         spat_water = df['water'].values
     except KeyError:
         log.warning('Water not represented in base layer.  Representing water as 0 percent of grid.')
         spat_water = np.zeros_like(spat_grid_id)
 
-    # for aez scale
-    if c.agg_level == 2:
+    spat_region = df['region_id'].values
+    spat_metric = df['{0}_id'.format(c.metric.lower())].values
 
-        # for old style parsing of regaez field
-        # spat_region = np.int8(np.floor(spat_metric_region / 100))
-        # spat_metric = np.int8(spat_metric_region % 100)
+    # ensure that the observed data represents all expected region ids
+    unique_spat_region = np.unique(spat_region)
+    valid_region_test = set(region_seq) - set(unique_spat_region)
 
-        # for new parsing style
-        spat_region = df['region_id'].values
-        spat_metric = df['{0}_id'.format(c.metric.lower())].values
+    if len(valid_region_test) > 0:
+        log.error('Observed spatial data must have all regions represented.')
+        raise ValidationException
 
-    # for basin scale
-    elif c.agg_level == 1:
-        # spat_r = df['region_id'].values
-        # spat_region = np.ones_like(spat_r)
+    # ensure that the observed data represents all expected metric ids
+    unique_spat_metric = np.unique(spat_metric)
+    valid_metric_test = set(metric_seq) - set(unique_spat_metric)
 
-        spat_region = df['region_id'].values
-        spat_metric = df['{0}_id'.format(c.metric.lower())].values
+    if len(valid_metric_test) > 0:
+        log.error('Observed spatial data must have all {}_id represented.'.format(c.metric.lower()))
+        raise ValidationException
 
-    sequence_list = sequence_metric_dict.keys()
-    max_key = max(sequence_list)
-
-    # get a list of aez or basin ids that are in observed but not in projected data
-    not_in_metrics = set(np.unique(spat_metric)) - set(sequence_list)
-
-    # add observed basins not in projected to the sequential dictionary
-    for index, k in enumerate(not_in_metrics):
-        adder = index + 1
-
-        sequence_metric_dict[k] = max_key + adder
-        max_key += adder
-
-    # apply the new sequential metric ids to the data
+    # adjust the numbering of metrics in the observed data
     spat_metric = np.vectorize(sequence_metric_dict.get)(spat_metric)
 
     # get the total number of grid cells
@@ -368,7 +372,7 @@ def read_base(log, c, spat_landclasses, sequence_metric_dict):
     if c.model.lower() == 'gcam' and c.agg_level == 2:
         spat_region[spat_region == 30] = 11
 
-    # cell area from lat: lat_correction_factor * (lat_km at equator * lon_km at equator) * (resolution squred) = sqkm
+    # cell area from lat: lat_correction_factor * (lat_km at equator * lon_km at equator) * (resolution squared) = sqkm
     cellarea = np.cos(np.radians(spat_coords[:, 0])) * (111.32 * 110.57) * (c.resin**2)
 
     # create an array with the actual percentage of the grid cell included in the data; some are cut by AEZ or Basin

--- a/demeter/demeter_io/reader.py
+++ b/demeter/demeter_io/reader.py
@@ -102,7 +102,7 @@ def read_alloc(f, lc_col, output_level=3, delim=','):
         fcs = [i for i in df.columns if i != col]
 
         # extract target land cover values only from the dataframe and create Numpy array
-        arr = df[fcs].as_matrix()
+        arr = df[fcs].values
 
         if output_level == 3:
             return fcs, tcs, arr
@@ -213,7 +213,8 @@ def read_gcam_file(log, f, gcam_landclasses, start_yr, end_yr, scenario, region_
 
     # create land use area per year array converted from thousands km using area_factor
     target_years = [str(yr) for yr in user_years]
-    gcam_ludata = gdf[target_years].as_matrix() * area_factor
+
+    gcam_ludata = gdf[target_years].values * area_factor
 
     # create field for land class
     gdf['gcam_landname'] = gdf['landclass'].apply(lambda x: x.lower())
@@ -232,16 +233,16 @@ def read_gcam_file(log, f, gcam_landclasses, start_yr, end_yr, scenario, region_
         gdf['gcam_regionnumber'] = gdf['region'].map(lambda x: int(region_dict[x]))
 
     # create an array of AEZ or Basin positions
-    gcam_metric  = gdf['gcam_metric'].as_matrix()
+    gcam_metric  = gdf['gcam_metric'].values
 
     # create an array of AEZ or Basin ids; formerly gcam_aez; this has the original metric values - not sequential
-    metric_id_array = gdf['metric_id'].as_matrix()
+    metric_id_array = gdf['metric_id'].values
 
     # create an array of projected land use names
-    gcam_landname = gdf['gcam_landname'].as_matrix()
+    gcam_landname = gdf['gcam_landname'].values
 
     # create an array of GCAM region numbers
-    gcam_regionnumber = gdf['gcam_regionnumber'].as_matrix()
+    gcam_regionnumber = gdf['gcam_regionnumber'].values
 
     # create a list of GCAM regions represented
     l_allreg = gdf['region'].unique().tolist()
@@ -298,29 +299,29 @@ def read_base(log, c, spat_landclasses):
 
     try:
         # create array with only spatial land cover values
-        spat_ludata = df[spat_landclasses].as_matrix()
+        spat_ludata = df[spat_landclasses].values
     except KeyError as e:
         log.error('Fields are listed in the spatial allocation file that do not exist in the base layer.')
         log.error(e)
 
     # create array of latitude, longitude coordinates
     try:
-        spat_coords = df[['latcoord', 'loncoord']].as_matrix()
+        spat_coords = df[['latcoord', 'loncoord']].values
     except KeyError:
-        spat_coords = df[['latitude', 'longitude']].as_matrix()
+        spat_coords = df[['latitude', 'longitude']].values
 
     # create array of metric (AEZ or basin id) per region; naming convention (regionmetric); formerly spat_aezreg
     try:
-        spat_metric_region = df['regaez'].as_matrix()
+        spat_metric_region = df['regaez'].values
     except:
         spat_metric_region = None
 
     # create array of grid ids
-    spat_grid_id = df[c.pkey].as_matrix()
+    spat_grid_id = df[c.pkey].values
 
     try:
         # create array of water areas
-        spat_water = df['water'].as_matrix()
+        spat_water = df['water'].values
     except KeyError:
         log.warning('Water not represented in base layer.  Representing water as 0 percent of grid.')
         spat_water = np.zeros_like(spat_grid_id)
@@ -333,14 +334,14 @@ def read_base(log, c, spat_landclasses):
         # spat_metric = np.int8(spat_metric_region % 100)
 
         # for new parsing style
-        spat_region = df['region_id'].as_matrix()
-        spat_metric = df['{0}_id'.format(c.metric.lower())].as_matrix()
+        spat_region = df['region_id'].values
+        spat_metric = df['{0}_id'.format(c.metric.lower())].values
 
     # for basin scale
     elif c.agg_level == 1:
-        spat_r = df['region_id'].as_matrix()
+        spat_r = df['region_id'].values
         spat_region = np.ones_like(spat_r) # np.zeros_like(spat_r) + 9999
-        spat_metric = df['{0}_id'.format(c.metric.lower())].as_matrix()
+        spat_metric = df['{0}_id'.format(c.metric.lower())].values
 
     # get the total number of grid cells
     ngrids = len(df)

--- a/demeter/demeter_io/reader.py
+++ b/demeter/demeter_io/reader.py
@@ -353,8 +353,10 @@ def read_base(log, c, spat_landclasses, sequence_metric_dict):
 
     # add observed basins not in projected to the sequential dictionary
     for index, k in enumerate(not_in_metrics):
-        sequence_metric_dict[k] = max_key + index
-        max_key += index
+        adder = index + 1
+
+        sequence_metric_dict[k] = max_key + adder
+        max_key += adder
 
     # apply the new sequential metric ids to the data
     spat_metric = np.vectorize(sequence_metric_dict.get)(spat_metric)

--- a/demeter/process.py
+++ b/demeter/process.py
@@ -149,6 +149,15 @@ class ProcessStep:
         :param transitions:             area in sqkm of each transition from one land class to another (n_cells, n_landclasses, n_landclasses)
         :param user_years:              a list of user selected years to process
         """
+
+
+        # TODO: convert metric_id back to original
+        print(sorted(np.unique(self.s.spat_aez)))
+
+        print(sorted(np.unique(self.s.spat_region)))
+
+        raise ValueError
+
         # convert land cover from sqkm per grid cell per land class to fraction for mapping (n_grids, n_landclasses)
         map_fraction_lu = self.s.spat_ludataharm / np.tile(self.s.cellarea, (self.l_fcs, 1)).T
 

--- a/demeter/process.py
+++ b/demeter/process.py
@@ -149,14 +149,9 @@ class ProcessStep:
         :param transitions:             area in sqkm of each transition from one land class to another (n_cells, n_landclasses, n_landclasses)
         :param user_years:              a list of user selected years to process
         """
-
-
-        # TODO: convert metric_id back to original
-        print(sorted(np.unique(self.s.spat_aez)))
-
-        print(sorted(np.unique(self.s.spat_region)))
-
-        raise ValueError
+        # convert metric_id back to the original
+        revert_metric_dict = {self.s.sequence_metric_dict[k]: k for k in self.s.sequence_metric_dict.iterkeys()}
+        orig_spat_aez = np.vectorize(revert_metric_dict.get)(self.s.spat_aez)
 
         # convert land cover from sqkm per grid cell per land class to fraction for mapping (n_grids, n_landclasses)
         map_fraction_lu = self.s.spat_ludataharm / np.tile(self.s.cellarea, (self.l_fcs, 1)).T
@@ -221,7 +216,7 @@ class ProcessStep:
         # save land cover data for the time step
         if (self.c.save_tabular == 1) and (self.step in self.c.target_years_output):
             self.log.info("Saving tabular land cover data for time step {0}...".format(self.step))
-            wdr.lc_timestep_csv(self.c, self.step, self.s.final_landclasses, self.s.spat_coords, self.s.spat_aez,
+            wdr.lc_timestep_csv(self.c, self.step, self.s.final_landclasses, self.s.spat_coords, orig_spat_aez,
                                 self.s.spat_region, self.s.spat_water, self.s.cellarea, self.s.spat_ludataharm,
                                 self.c.metric, self.c.tabular_units)
 

--- a/demeter/staging.py
+++ b/demeter/staging.py
@@ -81,6 +81,7 @@ class Stage:
         self.gcam_landmatrix = None
         self.ixr_ixm_ixg = None
         self.metric_id_array = None
+        self.sequence_metric_dict = None
 
         # populate
         self.stage()
@@ -158,7 +159,7 @@ class Stage:
 
         # unpack variables
         self.user_years, self.gcam_ludata, self.gcam_aez, self.gcam_landname, self.gcam_regionnumber, self.allreg, \
-        self.allregnumber, self.allregaez, self.allaez, self.metric_id_array = gcam_data
+        self.allregnumber, self.allregaez, self.allaez, self.metric_id_array, self.sequence_metric_dict = gcam_data
 
         self.log.info('PERFORMANCE:  Projected landuse data prepared in {0} seconds'.format(time.time() - t0))
 
@@ -173,11 +174,11 @@ class Stage:
         t0 = time.time()
 
         # extract and process base layer land cover data
-        base_data = rdr.read_base(self.log, self.c, self.spat_landclasses)
+        base_data = rdr.read_base(self.log, self.c, self.spat_landclasses, self.sequence_metric_dict)
 
         # unpack variables
         self.spat_ludata, self.spat_water, self.spat_coords, self.spat_aez_region, self.spat_grid_id, self.spat_aez, \
-        self.spat_region, self.ngrids, self.cellarea, self.celltrunk = base_data
+        self.spat_region, self.ngrids, self.cellarea, self.celltrunk, self.sequence_metric_dict = base_data
 
         self.log.info('PERFORMANCE:  Base spatial landuse data prepared in {0} seconds'.format(time.time() - t0))
 

--- a/example/inputs/allocation/kernel_density_weighting.csv
+++ b/example/inputs/allocation/kernel_density_weighting.csv
@@ -1,2 +1,2 @@
 category,forest,shrub,grass,crops,urban,snow,sparse
-kernel_density,1,1,1,1,1,1,1
+kernel_density,1,1,1,0.4,1,1,1


### PR DESCRIPTION
When the projected data did not included all metrics (e.g., basins) the sequencing was incorrect.  To correct this, the original metric values are kept in a dictionary along with their sequenced value.  Metric values are also harmonized in the observed data to ensure matching.  The original metric ids are reapplied before files are output.  Other changes were also made:

- The kernel density weighting file in example/inputs/allocation had the incorrect weighting for crops.  This was adjusted to 0.4 as originally intended.
- A validation exception will now be raised if the observed data does not have an allocation for all metrics
- Unclassified data listed as "0" will be now accounted for if present in the observed data

I conducted tests with the changes made against the pre-change outputs when ran under the same conditions using Pandas.testing.assert_frame_equal.  All tests passed.